### PR TITLE
Improve recipe preview

### DIFF
--- a/app/src/app/screens/Dashboard/screens/Category/components/Card/constants.js
+++ b/app/src/app/screens/Dashboard/screens/Category/components/Card/constants.js
@@ -1,10 +1,11 @@
+export const DEFAULT_COLOR = '#CDD2D2';
 export const COLORS = [
+  DEFAULT_COLOR,
   '#D25401',
   '#2A3E50',
   '#17BC9B',
   '#2880B9',
   '#FECB65',
   '#AA48EE',
-  '#FF7293',
-  '#CDD2D2'
+  '#FF7293'
 ];

--- a/app/src/app/screens/Dashboard/screens/Category/components/Card/index.tsx
+++ b/app/src/app/screens/Dashboard/screens/Category/components/Card/index.tsx
@@ -6,7 +6,7 @@ import { Recipe } from '~constants/interfaces/recipe';
 
 import RecipePreview from '../RecipePreview/index';
 
-import { COLORS } from './constants';
+import { COLORS, DEFAULT_COLOR } from './constants';
 import styles from './styles.module.scss';
 
 interface Props {
@@ -21,7 +21,9 @@ function Card({ recipe, number }: Props) {
     .replace(':recipe', recipe.title)
     .replace(':tech', recipe.tech);
 
-  const cardColor = { '--card-color': COLORS[Math.floor(number % COLORS.length)] } as React.CSSProperties;
+  const cardColor = {
+    '--card-color': recipe.config.thumbnail ? DEFAULT_COLOR : COLORS[Math.floor(number % COLORS.length)]
+  } as React.CSSProperties;
 
   return (
     // eslint-disable-next-line react/forbid-dom-props

--- a/app/src/app/screens/Dashboard/screens/Category/components/RecipePreview/index.tsx
+++ b/app/src/app/screens/Dashboard/screens/Category/components/RecipePreview/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import cn from 'classnames';
 
 import { Recipe } from '~constants/interfaces/recipe';
 
@@ -21,7 +22,12 @@ function RecipePreview({ className, recipe, thumbnail }: Props) {
       const Elem = preview.type;
       return (
         <div className={`full-width row middle center ${className}`}>
-          <Elem src={preview.url} className={`full-width row middle center ${styles.cardIframe}`} />
+          <Elem
+            src={preview.url}
+            className={cn('full-width', 'row', 'middle', 'center', styles[`card-${preview.type}`], {
+              [styles.cardThumbnailIframe]: preview.type === 'iframe' && thumbnail
+            })}
+          />
         </div>
       );
     }

--- a/app/src/app/screens/Dashboard/screens/Category/components/RecipePreview/styles.module.scss
+++ b/app/src/app/screens/Dashboard/screens/Category/components/RecipePreview/styles.module.scss
@@ -3,7 +3,14 @@
   padding: 10px;
 }
 
+.card-img {
+  object-fit: scale-down;
+}
+
 .card-iframe {
   border-style: none;
-  object-fit: scale-down;
+}
+
+.card-thumbnail-iframe {
+  transform: scale(0.8);
 }


### PR DESCRIPTION
## Summary

Improve recipe preview
* Remove random background card color if the recipe has a config (web componentes still have random color)
* Scale iframe recipes a bit, maybe we can improve centering by adjusting the react-cookbook code, but it also depends on the recipes.
## Screenshots

### Before
<img width="981" alt="Captura de Pantalla 2020-07-16 a la(s) 14 47 37" src="https://user-images.githubusercontent.com/4098152/87704892-6e111080-c773-11ea-890d-c7626f407a07.png">

### After
<img width="974" alt="Captura de Pantalla 2020-07-16 a la(s) 14 47 44" src="https://user-images.githubusercontent.com/4098152/87704898-710c0100-c773-11ea-80ba-28b8ebf405d6.png">

### Before
<img width="992" alt="Captura de Pantalla 2020-07-16 a la(s) 14 50 04" src="https://user-images.githubusercontent.com/4098152/87705022-a6b0ea00-c773-11ea-938b-febc392bbe18.png">

### After
<img width="945" alt="Captura de Pantalla 2020-07-16 a la(s) 14 50 34" src="https://user-images.githubusercontent.com/4098152/87705074-b9c3ba00-c773-11ea-8d2b-5a5d9c99fe26.png">

### Before
<img width="791" alt="Captura de Pantalla 2020-07-16 a la(s) 14 51 50" src="https://user-images.githubusercontent.com/4098152/87705191-eb3c8580-c773-11ea-8678-7a78bc59f25c.png">

### After
<img width="771" alt="Captura de Pantalla 2020-07-16 a la(s) 14 51 53" src="https://user-images.githubusercontent.com/4098152/87705202-f099d000-c773-11ea-8184-f8068c88a74e.png">
