### PR TITLE
fixed react recipes not showing up in sidebar

### DIFF
--- a/app/src/utils/queries.ts
+++ b/app/src/utils/queries.ts
@@ -3,6 +3,7 @@ import { gql } from 'apollo-boost';
 const RECIPES_BRANCH = process.env.REACT_APP_RECIPES_BRANCH;
 export const COOKBOOK_PREFIX = 'cookbook-';
 export const RECIPES_DIRECTORY = 'recipes';
+export const SRC_DIRECTORY = 'src';
 
 interface QueryBuilderOptions {
   tech?: string;
@@ -168,6 +169,13 @@ export const getCategoriesAndTechs = () =>
                 ... on Tree {
                   entries {
                     name
+                    object {
+                      ... on Tree {
+                        entries {
+                          name
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/app/src/utils/techs.ts
+++ b/app/src/utils/techs.ts
@@ -1,25 +1,23 @@
-import { uniq, flatten } from 'lodash';
+import { uniq, flatten, entries } from 'lodash';
 
 import { Categories } from '~components/Sidebar/interface';
 
-import { COOKBOOK_PREFIX, RECIPES_DIRECTORY } from './queries';
+import { COOKBOOK_PREFIX, RECIPES_DIRECTORY, SRC_DIRECTORY } from './queries';
+
+interface Directory {
+  oid?: string;
+  name: string;
+  object?: {
+    entries: Directory[];
+  }
+}
 
 export interface TechsResult {
   repository: {
     object: {
-      entries: {
-        name: string;
-        object: {
-          entries: {
-            name: string;
-            object: {
-              entries: Categories[];
-            };
-          }[];
-        };
-      }[];
+      entries: Directory[];
     };
-  };
+  }
 }
 
 export const parseTechs = (data: TechsResult) =>
@@ -27,10 +25,15 @@ export const parseTechs = (data: TechsResult) =>
     .filter(entry => entry.name.startsWith(COOKBOOK_PREFIX))
     .map(cookbook => ({
       name: cookbook.name.substring(COOKBOOK_PREFIX.length),
-      categories: cookbook.object.entries
+      categories: cookbook.object?.entries
         .find(entry => entry.name === RECIPES_DIRECTORY)
-        ?.object.entries.map(entry => entry.name)
+        ?.object?.entries.map(entry => entry.name)
     }));
+
+const getSubdir = (dir: Directory, subDir: string) => {
+  const recipesDir = dir.object?.entries.find(entry => entry.name === subDir);
+  return recipesDir?.object?.entries.map(entry => entry.name);
+}
 
 export const parseCategories = (data: TechsResult) =>
   uniq(
@@ -38,9 +41,15 @@ export const parseCategories = (data: TechsResult) =>
       data.repository.object.entries
         .filter(entry => entry.name.startsWith(COOKBOOK_PREFIX))
         .map(cookbook =>
-          cookbook.object.entries
-            .find(entry => entry.name === RECIPES_DIRECTORY)
-            ?.object.entries.map(entry => entry.name)
+          {
+            const recipesDir = getSubdir(cookbook, RECIPES_DIRECTORY);
+            if (recipesDir) {
+              return recipesDir;
+            }
+
+            const srcDir = cookbook.object?.entries.find(entry => entry.name === SRC_DIRECTORY);
+            return srcDir && getSubdir(srcDir, RECIPES_DIRECTORY);
+          }
         )
     ).filter(category => !!category) as string[]
   );

--- a/cookbook-react/src/recipes/inputs/barcelona/styles.module.scss
+++ b/cookbook-react/src/recipes/inputs/barcelona/styles.module.scss
@@ -13,7 +13,6 @@ $background-color: #FFF;
 $text-color: #08080D;
 $label-color: #525256;
 
-
 .input-wrapper {
   max-width: 150px;
   position: relative;


### PR DESCRIPTION
## Summary

Changed parseCategories so in case it can't find the `recipes` directory, it looks inside the `src` directory for it. We had to do this because recipes in React are inside `src` (which is necessary for the tests to work)
This also means we have to fetch one more level of folders in Github

## Screenshots

![pivot](https://user-images.githubusercontent.com/5349650/99830320-4c1e0500-2b3c-11eb-8f5a-59a803abd799.gif)

