### PR TITLE
[React] fixed disabled input test for barcelona input

### DIFF
--- a/cookbook-react/src/recipes/inputs/barcelona/index.test.tsx
+++ b/cookbook-react/src/recipes/inputs/barcelona/index.test.tsx
@@ -107,9 +107,13 @@ describe('Barcelona Input', () => {
     const component = <Input {...staticProps} disabled />;
 
     it('shows the input as disabled', async () => {
-      const { getByRole } = render(component);
-      const inputElement = await getByRole('textbox');
-      expect(inputElement?.getAttribute('disabled')).toBeTruthy();
+      const { findByRole } = render(component);
+
+      const inputElement = await findByRole('textbox');
+      const disabledAttribute = inputElement?.getAttribute('disabled');
+
+      expect(disabledAttribute).not.toBe(null);
+      expect(disabledAttribute).not.toBe(false);
     });
   });
 });

--- a/cookbook-react/src/recipes/screens/login/index.test.tsx
+++ b/cookbook-react/src/recipes/screens/login/index.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
-import 'mutationobserver-shim';
-
 import Login from './index';
 
 jest.mock('i18next', () => ({

--- a/cookbook-react/src/recipes/screens/registration/index.test.tsx
+++ b/cookbook-react/src/recipes/screens/registration/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import 'mutationobserver-shim';
 
 import Registration from './';
 

--- a/cookbook-react/src/setupTests.ts
+++ b/cookbook-react/src/setupTests.ts
@@ -1,6 +1,7 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import '@testing-library/jest-dom/extend-expect';
+import 'mutationobserver-shim';
 
 configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
## Summary

- Fixed a test for the Barcelona input that tested the disabled feature
- Moved the `mutationobserver-shim` import (which fixes an issue with react-hook-form) to setupTest

