### PR TITLE
fixed github token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env*
 
 now.json
+vercel.json
 .vercel
 
 node_modules

--- a/app/src/services/AuthServices.js
+++ b/app/src/services/AuthServices.js
@@ -3,7 +3,7 @@ import { create } from 'apisauce';
 const api = create({ baseURL: process.env.REACT_APP_AUTH_BASE_URL });
 
 const getTokenFromResponse = queryParams =>
-  queryParams.match(/access_token=[a-z0-9]+/g)[0].substring('access_token='.length);
+  queryParams.match(/access_token=[a-zA-Z0-9_]+/g)[0].substring('access_token='.length);
 
 export const storeToken = response => {
   const token = getTokenFromResponse(response.data);


### PR DESCRIPTION
## Summary

- Changed redirect url in api settings to match vercel instead of `now`
- Github Token can now have upeprcase letters and starts with `gho_`, so the logic to extract the token was adapted
