### PR TITLE
[RN] Recipe/ Inactivity handler hook

### DIFF
--- a/app/src/config/api.js
+++ b/app/src/config/api.js
@@ -1,4 +1,5 @@
 import { create } from 'apisauce';
+import { removeCurrentUser } from '../services/AuthServices';
 
 const baseURL = process.env.REACT_APP_AUTH_BASE_URL;
 
@@ -23,6 +24,7 @@ export const apiSetup = dispatch => {
        * TODO: These callbacks should only be called if no other callback was asigned for the response.
        * - dispatch(alertActions.error(i18next.t('apiErrors:expired')));
        */
+      removeCurrentUser();
     }
   });
 

--- a/cookbook-react-native/ios/Podfile.lock
+++ b/cookbook-react-native/ios/Podfile.lock
@@ -67,15 +67,15 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - libwebp (1.1.0):
-    - libwebp/demux (= 1.1.0)
-    - libwebp/mux (= 1.1.0)
-    - libwebp/webp (= 1.1.0)
-  - libwebp/demux (1.1.0):
+  - libwebp (1.2.0):
+    - libwebp/demux (= 1.2.0)
+    - libwebp/mux (= 1.2.0)
+    - libwebp/webp (= 1.2.0)
+  - libwebp/demux (1.2.0):
     - libwebp/webp
-  - libwebp/mux (1.1.0):
+  - libwebp/mux (1.2.0):
     - libwebp/demux
-  - libwebp/webp (1.1.0)
+  - libwebp/webp (1.2.0)
   - OpenSSL-Universal (1.0.2.19):
     - OpenSSL-Universal/Static (= 1.0.2.19)
   - OpenSSL-Universal/Static (1.0.2.19)
@@ -313,10 +313,10 @@ PODS:
     - React
   - RNCMaskedView (0.1.10):
     - React
-  - RNFastImage (8.1.5):
+  - RNFastImage (8.3.0):
     - React
-    - SDWebImage (~> 5.0)
-    - SDWebImageWebPCoder (~> 0.4.1)
+    - SDWebImage (~> 5.8)
+    - SDWebImageWebPCoder (~> 0.6.1)
   - RNGestureHandler (1.6.1):
     - React
   - RNLocalize (1.4.0):
@@ -328,9 +328,9 @@ PODS:
   - SDWebImage (5.8.0):
     - SDWebImage/Core (= 5.8.0)
   - SDWebImage/Core (5.8.0)
-  - SDWebImageWebPCoder (0.4.1):
+  - SDWebImageWebPCoder (0.6.1):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.5)
+    - SDWebImage/Core (~> 5.7)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -503,7 +503,7 @@ SPEC CHECKSUMS:
   FlipperKit: 6dc9b8f4ef60d9e5ded7f0264db299c91f18832e
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
+  libwebp: e90b9c01d99205d03b6bb8f2c8c415e5a4ef66f0
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
@@ -530,16 +530,16 @@ SPEC CHECKSUMS:
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
   RNCAsyncStorage: d059c3ee71738c39834a627476322a5a8cd5bf36
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
-  RNFastImage: 35ae972d6727c84ee3f5c6897e07f84d0a3445e9
+  RNFastImage: 2ed80661d5ef384fb1b539f1f3c81a1733f92bc9
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
   RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244
   SDWebImage: 84000f962cbfa70c07f19d2234cbfcf5d779b5dc
-  SDWebImageWebPCoder: 36f8f47bd9879a8aea6044765c1351120fd8e3a8
+  SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: e2aa51174c10b07087f4caf4197963f9c3db8f39
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/cookbook-react-native/recipes/hooks/InactivityHandler/cookbook.json
+++ b/cookbook-react-native/recipes/hooks/InactivityHandler/cookbook.json
@@ -1,0 +1,6 @@
+{
+  "thumbnail": {
+    "type": "img",
+    "url": "https://blog.auriboxconsulting.com/wp-content/uploads/2019/02/reactnative.png"
+  }
+}

--- a/cookbook-react-native/recipes/hooks/InactivityHandler/readme.md
+++ b/cookbook-react-native/recipes/hooks/InactivityHandler/readme.md
@@ -1,0 +1,34 @@
+# Cookbook React Native Bootstrap: InactivityHandler hook Recipe
+
+## Installation
+
+If you want to add this recipe to a project that wasn't created with our [bootstrap](https://github.com/Wolox/wolmo-bootstrap-react-native), you will need to add the following [aliases](https://github.com/tleunen/babel-plugin-module-resolver#readme) and files under them to your project:
+
+### Interfaces files
+#### alias `@interfaces`
+
+* [globalInterfaces.ts](https://github.com/Wolox/wolmo-bootstrap-react-native/blob/master/generators/app/templates/src/interfaces/globalInterfaces.ts)
+
+## Usage
+
+This hook handles In-app inactivity and Background inactivity.
+
+Don't forget to replace **timeForInactivity** and **actionToDispatch** at _@hooks/useInactivityHandler_ before you call this hook.
+
+``` ts
+import { useInactivityHandler } from '@hooks/useInactivityHandler';
+...
+
+function App() {
+  const Inactivity = useInactivityHandler()
+
+  ...
+  return (
+    <Inactivity.Component style={Inactivity.style} {...Inactivity.handler}>
+      <AppNavigator>
+    </InactivityHandler.Component>
+  );
+}
+
+export default App;
+```

--- a/cookbook-react-native/recipes/hooks/InactivityHandler/useInactivityHandler.ts
+++ b/cookbook-react-native/recipes/hooks/InactivityHandler/useInactivityHandler.ts
@@ -1,0 +1,46 @@
+/* eslint-disable id-length */
+import { useCallback, useRef, ReactNode } from 'react';
+import { useDispatch } from 'react-redux';
+import { PanResponder, View } from 'react-native';
+import { Nullable } from '@interfaces/globalInterfaces';
+
+const containerStyle = { flex: 1 };
+const timeForInactivity = 6000; // Time to set user as inactive in milliseconds
+const actionToDispatch = null; // Action to dispatch when the user is inactive. Delete this line and import the action that you wanna dispatch.
+
+export const useInactivityHandler = () => {
+  const dispatch = useDispatch();
+  const timer = useRef<Nullable<ReturnType<typeof setInterval>>>(null);
+
+  const stopTimer = useCallback(() => {
+    if (timer.current) clearInterval(timer.current);
+  }, []);
+
+  const handleTouch = () => {
+    stopTimer();
+    const startTime = Date.now();
+    timer.current = setInterval(() => {
+      const elapsedTime = Date.now() - startTime;
+      if (elapsedTime >= timeForInactivity) {
+        // You can add a condition here for the dispatch, but the stopTimer() should always be called.
+        dispatch(actionToDispatch);
+        stopTimer();
+      }
+    }, 100)
+  };
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponderCapture: () => {
+        handleTouch();
+        return false;
+      }
+    })
+  ).current;
+
+  return {
+    Component: View,
+    style: containerStyle,
+    handler: panResponder.panHandlers
+  };
+};

--- a/cookbook-react-native/recipes/hooks/InactivityHandler/useInactivityHandler.ts
+++ b/cookbook-react-native/recipes/hooks/InactivityHandler/useInactivityHandler.ts
@@ -1,5 +1,5 @@
 /* eslint-disable id-length */
-import { useCallback, useRef, ReactNode } from 'react';
+import { useCallback, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { PanResponder, View } from 'react-native';
 import { Nullable } from '@interfaces/globalInterfaces';


### PR DESCRIPTION
## Summary

Implement hook for React Native that handles the Inactivity of the user in-app and in-background.

I've also fixed an issue:
- Added a monitor at api.js to remove current user when we get a 401.

## Screenshots

**_This feature has no visual changes._**
