### PR TITLE
Error boundary implementation

### DIFF
--- a/cookbook-react-native/recipes/errorBoundary/cookbook.json
+++ b/cookbook-react-native/recipes/errorBoundary/cookbook.json
@@ -1,0 +1,6 @@
+{
+  "thumbnail": {
+    "type": "img",
+    "url": "https://blog.auriboxconsulting.com/wp-content/uploads/2019/02/reactnative.png"
+  }
+}

--- a/cookbook-react-native/recipes/errorBoundary/index.tsx
+++ b/cookbook-react-native/recipes/errorBoundary/index.tsx
@@ -1,0 +1,25 @@
+import { Component, ReactElement } from 'react';
+
+type Props = {
+  errorComponent: ReactElement;
+};
+type State = {
+  error: boolean;
+};
+
+class ErrorBoundary extends Component<Props, State> {
+  state = { error: false };
+
+  static getDerivedStateFromError(_: Error) {
+    return { error: true };
+  }
+
+  render() {
+    if (this.state.error) {
+      return this.props.errorComponent;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/cookbook-react-native/recipes/errorBoundary/readme.md
+++ b/cookbook-react-native/recipes/errorBoundary/readme.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-Component that catchs JavaScript errors and displays a fallback UI instead of the component tree that crashed.
+Component that catches JavaScript errors and displays a fallback UI instead of the component tree that crashed.
 
 ``` ts
 import ErrorBoundary from 'recipes/errorBoundary';

--- a/cookbook-react-native/recipes/errorBoundary/readme.md
+++ b/cookbook-react-native/recipes/errorBoundary/readme.md
@@ -1,0 +1,27 @@
+# Cookbook React Native Bootstrap: Error Boundary Recipe
+
+## Usage
+
+Component that catchs JavaScript errors and displays a fallback UI instead of the component tree that crashed.
+
+``` ts
+import ErrorBoundary from 'recipes/errorBoundary';
+...
+
+function App() {
+  ...
+  return (
+    <ErrorBoundary errorComponent={<ErrorComponent />}>
+      <Component />
+    </ErrorBoundary>
+  );
+}
+
+export default App;
+```
+
+## Props
+
+| Prop  | Default  | Type | Description |
+| :------------ |:---------------:| :---------------:| :-----|
+| errorComponent | - | React.FunctionComponent | Component that will be displayed instead of component tree that crashed. |


### PR DESCRIPTION
## Summary

Add error boundary recipe, whose function is to catch JavaScript errors and display a fallback UI instead of the component tree that crashed.